### PR TITLE
Move to Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@
 
 ### Install dependencies
 1. Clone the repository and checkout the develop branch (default)
-1. Install dependencies with `pip install -r requirements.txt` (can be in virtualenv)
+1. Install Python 3
+1. Install dependencies with `pip3 install -r requirements.txt` (can be in virtualenv)
 1. Install `pyqt5-tools` Global or user python installation (not virtualenv)
 
 ### Editing the `.ui` files

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,9 @@
-pymodbus==1.5.1
-PyQt5==5.10.1
-pyserial==3.4
-sip==4.19.8
-six==1.11.0
+packaging==20.8
+pymodbus==2.4.0
+pyparsing==2.4.7
+PyQt5==5.15.2
+PyQt5-sip==12.8.1
+pyserial==3.5
+sip==6.0.0
+six==1.15.0
+toml==0.10.2

--- a/visualizer/modbus_worker.py
+++ b/visualizer/modbus_worker.py
@@ -46,13 +46,13 @@ class ModbusWorker(QObject):
         if self.client:
             self.client.close()  # Properly close the client when re-configuring. Needed for Serial.
 
-        if settings["network_type"] is "tcp":
+        if settings["network_type"] == "tcp":
             host = settings["host"]
             port = settings["port"]
             self.client = ModbusTcpClient(host, port)
             self.console_message_available.emit(f"Attempting to connect to {host} on port {port}")
 
-        elif settings["network_type"] is "serial":
+        elif settings["network_type"] == "serial":
             port = settings["port"]
             protocol = settings["protocol"]
             baudrate = settings["baudrate"]

--- a/visualizer/utils.py
+++ b/visualizer/utils.py
@@ -100,7 +100,7 @@ def format_write_value(string, dtype='H', byte_order='>', word_order='>'):
         num_txt = string[1:]
 
     radix = RADIX_PREFIX.get(num_txt[:2], 10)
-    if radix is not 10:
+    if radix != 10:
         num_txt = string[2:]
 
     vals = []


### PR DESCRIPTION
Thanks for the modbus_visualizer project. I used it to explore some options on my heatpump. But I had to make some quick & dirty changes to make it run with Python 3 on my mac (I could not test anything with the `pyqt5-tools`).

> DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained.